### PR TITLE
UX and code cleanup work

### DIFF
--- a/back-end/src/app.js
+++ b/back-end/src/app.js
@@ -203,27 +203,27 @@ router.post('/api/v1/layers/submit', async (ctx, next) => {
 		console.log('Inserting layer submission into database for approval...');
 		await database.LayerSubmission.create(submissionData);
 	} catch ( e ) {
-		if (e.name == 'SequelizeUniqueConstraintError') {
+		if (e.name === 'SequelizeUniqueConstraintError') {
 			console.log('Cannot insert layer submission into database, layer ARN already exists!');
 			ctx.body = {
-				'success': false,
-				'msg': 'That Lambda layer has already been submitted for approval.'
-			}
+				success: false,
+				msg: 'That Lambda layer has already been submitted for approval.'
+			};
 			return
 		}
 		throw e;
 	}
 
 	// If Mailgun is enabled, send email about it.
-	if(emailer.mailgun) {
+	if (emailer.mailgun) {
 		await emailer.sendSubmissionApprovalLink(
 			submissionData
 		);
 	}
 
 	ctx.body = {
-		'success': true,
-		'msg': 'Thank you for your submission, it will be reviewed and if approved imported into the database.'
+		success: true,
+		msg: 'Thank you for your submission, it will be reviewed and if approved imported into the database.'
 	}
 });
 

--- a/front-end/.eslintrc.js
+++ b/front-end/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true
+  },
+  extends: ['plugin:vue/essential'],
+  rules: {
+    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    quotes: ['error', 'single', { allowTemplateLiterals: true, avoidEscape: true }]
+  }
+};

--- a/front-end/src/components/LambdaLayerDownloader.vue
+++ b/front-end/src/components/LambdaLayerDownloader.vue
@@ -1,77 +1,72 @@
 <template>
-    <div class="main mb-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-9">
+      <div class="lambda-layer-downloader">
         <h3 class="search-title"><font-awesome-icon icon="download" /> Download Layer <code>.zip</code> by ARN</h3>
         <br />
         <p>
           <b-form-group description="The ARN of the Lambda layer you'd like to download.">
-            <b-form-input @change="validate_layer" v-model="layer_arn" :state="valid_layer" class="search-box" size="lg" type="text" placeholder="arn:aws:lambda:us-west-2:000000000000:layer:example-layer:1" autofocus></b-form-input>
+            <b-form-input @change="validateLayer" v-model="layerArn" :state="validLayer" class="search-box" size="lg" type="text" placeholder="arn:aws:lambda:us-west-2:000000000000:layer:example-layer:1" autofocus></b-form-input>
             <b-form-invalid-feedback>
               This is either not a valid Lambda ARN, or attempting to download the layer failed (likely due to it not being mountable from any AWS account).
             </b-form-invalid-feedback>
           </b-form-group>
-          <b-button variant="primary" v-on:click="download_inputted_layer">
+          <b-button variant="primary" size="lg" v-on:click="downloadSuppliedLayer">
             <font-awesome-icon icon="download" /> Download Lambda Layer
           </b-button>
         </p>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
-import apiService from '../lib/api.js';
+import * as apiService from '../lib/api.js';
 
-/* eslint-disable no-alert, no-console */
 export default {
-    name: 'LambdaLayerDownloader',
-    props: {},
-    data: function() {
-      return {
-        layer_arn: '',
-        valid_layer: null
-      }
-    },
-    methods: {
-      validate_layer: async function() {
-        const layerExists = await apiService.isValidAndExistingLayer(
-          this.layer_arn
-        );
-        this.valid_layer = layerExists;
-      },
-      download_inputted_layer: async function() {
-        if(this.layer_arn.trim() === '') {
-          this.$toastr.e("Please provide a layer ARN to download.");
-          return
-        }
-
-        const layerExists = await apiService.isValidAndExistingLayer(
-          this.layer_arn
-        );
-
-        if(!layerExists) {
-          this.$toastr.e("Could not download layer. Make sure it exists and has the proper permissions set on it.");
-          return
-        }
-
-        await apiService.downloadLayer(
-          this.layer_arn
-        );
-
-        this.$toastr.s("Lambda layer .zip was downloaded successfully!");
-
-        this.layer_arn = '';
-        this.valid_layer = null;
-      }
+  name: 'LambdaLayerDownloader',
+  props: {},
+  data() {
+    return {
+      layerArn: '',
+      validLayer: null
     }
+  },
+  methods: {
+    async validateLayer() {
+      this.validLayer = await apiService.isValidAndExistingLayer(
+        this.layerArn
+      );
+    },
+    async downloadSuppliedLayer() {
+      if (this.layerArn.trim() === '') {
+        this.$toastr.e('Please provide a layer ARN to download.');
+        return
+      }
+
+      const layerExists = await apiService.isValidAndExistingLayer(
+        this.layerArn
+      );
+
+      if (!layerExists) {
+        this.$toastr.e('Could not download layer. Make sure it exists and has the proper permissions set on it.');
+        return
+      }
+
+      await apiService.downloadLayer(
+        this.layerArn
+      );
+
+      this.$toastr.s('Lambda layer .zip was downloaded successfully!');
+
+      this.layerArn = '';
+      this.validLayer = null;
+    }
+  }
 }
 </script>
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.main {
-    max-width: 700px;
-    margin: 0 auto;
-    padding-left: 10px;
-    padding-right: 10px;
-}
-
 h3 {
     margin: 40px 0 0;
 }

--- a/front-end/src/components/Layout.vue
+++ b/front-end/src/components/Layout.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="container main mb-5">
+    <router-view></router-view>
+  </div>
+</template>

--- a/front-end/src/components/Main.vue
+++ b/front-end/src/components/Main.vue
@@ -22,7 +22,7 @@
             </b-input-group-append>
           </b-input-group>
           <small class="form-text text-muted">
-            Searches for a layer by name. To get the correct ARN to use, please specify your region. All layers are available in every region.
+            Searches layers by name. To get the correct ARN to use, please specify your region. Every layer is available in every region.
           </small>
         </div>
         <hr />

--- a/front-end/src/components/Main.vue
+++ b/front-end/src/components/Main.vue
@@ -2,14 +2,15 @@
     <div class="row justify-content-center">
       <div class="col-10">
         <h1>Lambda Layer Database</h1>
-        <h2 class="text-muted">
+        <h2 class="text-muted mb-3">
           <i>Created and supported by the <a target="_blank" href="https://refinery.io">Refinery.io team</a></i>
         </h2>
-        <div class="w-100">
-          <h3 class="search-title"><font-awesome-icon icon="search" /> Search the Database</h3>
+        <hr/>
+        <div class="mt-4 mb-3 w-100 text-justify">
+          <h3 class="search-title mt-3 pb-2"><font-awesome-icon icon="search" /> Search the Database</h3>
           <b-input-group>
-            <b-form-input v-on:keyup="performSearch" v-model="query" class="search-box"
-                          size="lg" type="search" placeholder="pandoc, git, ssh, chrome..." autofocus>
+            <b-form-input v-on:keyup="performSearch" v-model="query" class="search-box" autofocus
+                          size="lg" type="search" placeholder="pandoc, git, ssh, chrome...">
             </b-form-input>
             <b-input-group-append>
               <b-dropdown v-bind:text="selectedRegion" size="lg" variant="dark">
@@ -20,8 +21,19 @@
               </b-dropdown>
             </b-input-group-append>
           </b-input-group>
+          <small class="form-text text-muted">
+            Searches for a layer by name. To get the correct ARN to use, please specify your region. All layers are available in every region.
+          </small>
         </div>
         <hr />
+        <div class="mt-4 mb-2 pb-0 text-justify" v-if="searchResults && searchResults.length > 0">
+          <h5 v-if="query === ''">
+            Available Layers:
+          </h5>
+          <h5 v-if="query !== ''">
+            Found {{searchResults.length}} Matching Layer{{searchResults.length > 1 ? 's' : ''}}:
+          </h5>
+        </div>
         <b-list-group>
           <b-list-group-item class="d-flex justify-content-between align-items-center text-center" variant="light"
                              v-if="searchResults.length === 0 && searchResultsLoading === false">
@@ -172,10 +184,6 @@ export default {
 </script>
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.search-title {
-    padding-bottom: 10px;
-}
-
 h3 {
     margin: 40px 0 0;
 }

--- a/front-end/src/components/Main.vue
+++ b/front-end/src/components/Main.vue
@@ -1,170 +1,179 @@
 <template>
-    <div class="main">
+    <div class="row justify-content-center">
+      <div class="col-10">
         <h1>Lambda Layer Database</h1>
         <h2 class="text-muted">
           <i>Created and supported by the <a target="_blank" href="https://refinery.io">Refinery.io team</a></i>
         </h2>
-        <h3 class="search-title"><font-awesome-icon icon="search" /> Search the Database</h3>
-        <b-input-group>
-          <b-form-input v-on:keyup="perform_search" v-model="query" class="search-box"
-                        size="lg" type="search" placeholder="pandoc, git, ssh, chrome..." autofocus>
-          </b-form-input>
-          <b-input-group-append>
-            <b-dropdown v-bind:text="selected_region" size="lg" variant="dark">
-              <b-dropdown-item v-for="region in supported_regions" v-bind:key="region"
-                               @click="selected_region = region">
-                {{region}}
-              </b-dropdown-item>
-            </b-dropdown>
-          </b-input-group-append>
-        </b-input-group>
+        <div class="w-100">
+          <h3 class="search-title"><font-awesome-icon icon="search" /> Search the Database</h3>
+          <b-input-group>
+            <b-form-input v-on:keyup="performSearch" v-model="query" class="search-box"
+                          size="lg" type="search" placeholder="pandoc, git, ssh, chrome..." autofocus>
+            </b-form-input>
+            <b-input-group-append>
+              <b-dropdown v-bind:text="selectedRegion" size="lg" variant="dark">
+                <b-dropdown-item v-for="region in supportedRegions" v-bind:key="region"
+                                 @click="selectedRegion = region">
+                  {{region}}
+                </b-dropdown-item>
+              </b-dropdown>
+            </b-input-group-append>
+          </b-input-group>
+        </div>
         <hr />
         <b-list-group>
-          <b-list-group-item class="d-flex justify-content-between align-items-center text-center" variant="dark" v-if="search_results.length === 0 && search_results_loading === false">
+          <b-list-group-item class="d-flex justify-content-between align-items-center text-center" variant="light"
+                             v-if="searchResults.length === 0 && searchResultsLoading === false">
             <div class="w-100">
-              <span>
-                No lambda layers found for your search query.
-              </span>
-              <br>
-              <span>
+              <h4 class="pt-3" v-if="query === ''">
+                No Lambda Layers were found in the database.
+              </h4>
+              <h4 class="pt-3" v-if="query !== ''">
+                No layers matching "{{query}}" were found.
+              </h4>
+              <h6 class="pb-1 pt-1 font-weight-light">
                 <router-link to="/submit">
                   Maybe consider submitting one for the database?
                 </router-link>
-              </span>
+              </h6>
             </div>
           </b-list-group-item>
 
-          <b-list-group-item v-if="search_results_loading">
-            <b-spinner variant="primary" label="Spinning" small></b-spinner> Loading search results...
+          <b-list-group-item v-if="searchResultsLoading" variant="light">
+            <h4 class="pt-4 pb-4">
+              <b-spinner variant="primary" type="grow" label="Spinning"></b-spinner> Loading search results...
+            </h4>
           </b-list-group-item>
 
-          <b-list-group-item style="text-align: left" v-for="(search_result, index) in search_results" v-bind:key="index">
-            <b>Description: </b> <p style="white-space: pre-wrap; display: inline">{{search_result.description}}</p>
+          <b-list-group-item style="text-align: left" v-for="(searchResult, index) in searchResults" v-bind:key="index">
+            <b>Description: </b> <p style="white-space: pre-wrap; display: inline">{{searchResult.description}}</p>
             <br />
-            <span v-if="search_result.source_link.trim() !== '' && !search_result.source_link.toLowerCase().startsWith('javascript')">
-              <b>Source: </b> <a v-bind:href="search_result.source_link" target="_blank">{{search_result.source_link}}</a>
+            <span v-if="searchResult.sourceLink.trim() !== '' && !searchResult.sourceLink.toLowerCase().startsWith('javascript')">
+              <b>Source: </b> <a v-bind:href="searchResult.sourceLink" target="_blank">{{searchResult.sourceLink}}</a>
             </span>
             <br />
-            <span v-if="search_result.submitter_name.trim() !== ''">
-              <b>Submitter: </b> {{search_result.submitter_name}}<br />
+            <span v-if="searchResult.submitterName.trim() !== ''">
+              <b>Submitter: </b> {{searchResult.submitterName}}<br />
             </span>
-            <span v-if="search_result.submitter_name.trim() === ''">
+            <span v-if="searchResult.submitterName.trim() === ''">
               <b>Submitter: </b> Anonymous<br />
             </span>
 
-            <span v-if="search_result.license.trim() !== ''">
-              <b>License: </b> {{search_result.license}}<br />
+            <span v-if="searchResult.license.trim() !== ''">
+              <b>License: </b> {{searchResult.license}}<br />
             </span>
-            <div class="input-group">
-              <b-form-input v-bind:value="search_result.layer_arn" disabled></b-form-input>
-              <span class="input-group-btn">
-                <button class="btn btn-primary" type="button" v-on:click="copy_layer_arn(search_result.layer_arn)">
+
+            <hr/>
+
+            <b-input-group class="mt-3">
+              <b-form-input v-bind:value="searchResult.layerArn" size="md" readonly></b-form-input>
+              <b-input-group-append>
+                <b-button variant="primary" size="sm" v-on:click="copyLayerArn(searchResult.layerArn)">
                   <font-awesome-icon icon="copy" />
                   Copy ARN
-                </button>
-              </span>
-            </div>
-            <div class="pt-2 pb-0">
-              <b-button block variant="primary" v-on:click="download_layer_zip(search_result.layer_arn)">
+                </b-button>
+              </b-input-group-append>
+              <small class="text-muted w-100 pt-sm-1">Copy the above ARN value to access this layer in your Lambda.</small>
+            </b-input-group>
+            <b-button-group class="pt-2 pb-1 w-100">
+              <b-button size="sm" variant="outline-dark" v-on:click="downloadLayerZip(searchResult.layerArn)">
                 <font-awesome-icon icon="download" /> Download Layer .zip
               </b-button>
-            </div>
-            <div class="pt-2 pb-0">
-              <b-button block variant="primary" v-bind:to="'/layer/' + search_result.id">
+
+              <b-button size="sm" variant="outline-primary" v-bind:to="'/layer/' + searchResult.id">
                 <font-awesome-icon icon="eye" /> View Layer Page
               </b-button>
-            </div>
+            </b-button-group>
           </b-list-group-item>
         </b-list-group>
+      </div>
     </div>
 </template>
 
 <script>
-import apiService from '../lib/api.js';
-import utils from '../lib/utils.js';
+import * as apiService from '../lib/api.js';
+import * as utils from '../lib/utils.js';
 
-/* eslint-disable no-alert, no-console */
 export default {
-    name: 'Main',
-    props: {},
-    data: function() {
-      return {
-        query: '',
-        internal_search_results: [],
-        search_results_loading: false,
-        supported_regions: [],
-        selected_region: 'us-west-2'
-      }
-    },
-    computed: {
-      select_formatted_supported_regions: function() {
-        return this.supported_regions.map(region => {
-          return {
-            'value': region,
-            'text': region
-          }
-        })
-      },
-      search_results: function() {
-        return this.internal_search_results.map(search_result => {
-          return {
-            ...search_result,
-            ...{
-              layer_arn: utils.replaceLayerRegion(
-                search_result.layer_arn,
-                this.selected_region
-              )
-            }
-          }
-        });
-      }
-    },
-    methods: {
-      copy_layer_arn: function(layer_arn) {
-        this.$copyText(layer_arn);
-        this.$toastr.s("Lambda layer ARN copied to clipboard!");
-      },
-      get_supported_regions: async function() {
-        this.supported_regions = await apiService.getSupportedRegions();
-      },
-      perform_search: async function() {
-        this.internal_search_results = [];
-        this.search_results_loading = true;
-        const result = await apiService.searchDatabase(
-          this.query
-        );
-        this.search_results_loading = false;
-
-        if(!result.success) {
-          this.$toastr.e("An error occurred while performing this search.");
-          return
+  name: 'Main',
+  props: {},
+  data: function () {
+    return {
+      query: '',
+      internalSearchResults: [],
+      searchResultsLoading: false,
+      supportedRegions: [],
+      selectedRegion: 'us-west-2'
+    }
+  },
+  computed: {
+    selectFormattedSupportedRegions() {
+      return this.supportedRegions.map(region => {
+        return {
+          value: region,
+          text: region
         }
+      })
+    },
+    searchResults() {
+      return this.internalSearchResults.map(searchResult => {
+        return {
+          ...searchResult,
+          layerArn: utils.replaceLayerRegion(
+            searchResult.layerArn,
+            this.selectedRegion
+          )
+        }
+      });
+    }
+  },
+  methods: {
+    copyLayerArn(layerArn) {
+      this.$copyText(layerArn);
+      this.$toastr.s('Lambda layer ARN copied to clipboard!');
+    },
+    async getRegionData() {
+      this.supportedRegions = await apiService.getSupportedRegions();
+    },
+    async performSearch() {
+      this.searchResultsLoading = true;
+      this.internalSearchResults = [];
 
-        this.internal_search_results = result.search_results;
-      },
-      download_layer_zip: async function(layer_arn) {
-        await apiService.downloadLayer(
-          layer_arn
+      try {
+        const query = this.query;
+
+        const results = await apiService.searchDatabase(
+          query
         );
-      },
+
+        // Confirm that the result is still relevant to the currently type data.
+        // If not, bail out because we may just be a delayed request.
+        if (this.query === query) {
+          this.internalSearchResults = results
+        }
+      } catch (e) {
+        this.$toastr.e('An error occurred while performing this search.');
+      } finally {
+        this.searchResultsLoading = false;
+      }
     },
-    beforeMount(){
-      this.perform_search();
-      this.get_supported_regions();
+    async downloadLayerZip(layerArn) {
+      await apiService.downloadLayer(
+        layerArn
+      );
     },
+  },
+  beforeMount() {
+    this.performSearch();
+    this.getRegionData();
+  }
 }
 </script>
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
 .search-title {
     padding-bottom: 10px;
-}
-
-.main {
-    max-width: 700px;
-    margin: 0 auto;
-    padding-left: 10px;
-    padding-right: 10px;
 }
 
 h3 {

--- a/front-end/src/components/SubmitLambdaLayer.vue
+++ b/front-end/src/components/SubmitLambdaLayer.vue
@@ -1,34 +1,55 @@
 <template>
-    <div class="hello mb-5">
-        <h1>Submit a New Lambda Layer for the Database</h1>
-        <div class="main">
-            <b-alert show variant="info">
-              <font-awesome-icon icon="info-circle" /> <b>Important!</b>
-              <p class="mb-1">
-              Confirm that the layer can be imported to other AWS accounts. Layers are private by default.
-              </p>
-              <span class="mb-0 pb-0">Layers may be made public via the following command:</span>
-                <span class="bg-dark p-1 d-block rounded">
-                <code class="text-light font-weight-normal">
-                  aws lambda add-layer-version-permission --layer-name LAYER_NAME --version-number LAYER_VERSION --statement-id public --action lambda:GetLayerVersion --principal "*" --region us-west-2
-                </code>
-              </span>
-            </b-alert>
-            <b-form>
+  <div class="row justify-content-center">
+    <div class="col-lg-9">
+      <h1>Submit New Lambda Layer</h1>
+      <hr/>
+      <div class="col-md-10 ml-auto mr-auto">
+        <p class="text-justify">
+          This form allows you to request a new layer to be added to the list of entries. Upon submission, your layer will be submitted for review by our team. Once approved, it will be available for general use.
+        </p>
+      </div>
+      <hr/>
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-10">
+            <div class="submit-lambda-layer text-justify">
+              <b-alert show variant="info">
+                <font-awesome-icon icon="info-circle" /> <b>Important!</b>
+                <p class="mb-2">
+                  Confirm that the layer can be imported to other AWS accounts. By default all Lambda layers are private.
+                </p>
+                <span class="mb-0 pb-0">Layers may be made public via the following command:</span>
+                  <span class="bg-dark p-1 d-block rounded text-left">
+                  <code class="text-light font-weight-normal">
+                    <div class="pl-1">
+                      aws lambda add-layer-version-permission \ <br>
+                      <div class="pl-2">
+                        --layer-name LAYER_NAME \ <br>
+                        --version-number LAYER_VERSION \ <br>
+                        --statement-id public \ <br>
+                        --action lambda:GetLayerVersion \ <br>
+                        --principal "*" \ <br>
+                        --region us-west-2
+                      </div>
+                    </div>
+                  </code>
+                </span>
+              </b-alert>
+              <b-form>
                 <b-form-group label="Lambda ARN" description="The ARN of the Lambda layer you'd like added to the database.">
-                    <b-form-input @change="validate_layer" :state="valid_layer" v-model="layer_arn" type="text" required placeholder="arn:aws:lambda:us-west-2:000000000000:layer:example-layer:1" autofocus></b-form-input>
-                    <b-form-invalid-feedback>
-                      This Lambda layer failed our validation check. Ensure your ARN is correct and that you've set the appropriate IAM permissions (see above).
-                    </b-form-invalid-feedback>
+                  <b-form-input @change="validateLayer" :state="validLayer" v-model="layerArn" type="text" required placeholder="arn:aws:lambda:us-west-2:000000000000:layer:example-layer:1" autofocus></b-form-input>
+                  <b-form-invalid-feedback>
+                    This Lambda layer failed our validation check. Ensure your ARN is correct and that you've set the appropriate IAM permissions (see above).
+                  </b-form-invalid-feedback>
                 </b-form-group>
                 <b-form-group label="Source Link" description="A link to a Github, website, or some other page with more information on the layer.">
-                    <b-form-input v-model="source_link"  type="text" required placeholder="https://www.example.com/info-on-this-cool-lambda-layer"></b-form-input>
+                  <b-form-input v-model="sourceLink"  type="text" required placeholder="https://www.example.com/info-on-this-cool-lambda-layer"></b-form-input>
                 </b-form-group>
                 <b-form-group label="Name/Handle" description="Your name or handle to list on the layer page, leave blank if you don't care to be credited.">
-                    <b-form-input v-model="submitter_name" type="text" required placeholder="John Doe"></b-form-input>
+                  <b-form-input v-model="submitterName" type="text" required placeholder="John Doe"></b-form-input>
                 </b-form-group>
                 <b-form-group label="Description/README" description="A description of what the layer is and what it does.">
-                  <b-form-textarea :state="is_description_valid" v-model="description" placeholder="Enter something..." rows="3" max-rows="6"></b-form-textarea>
+                  <b-form-textarea :state="isDescriptionValid" v-model="description" placeholder="Enter something..." rows="3" max-rows="6"></b-form-textarea>
                   <b-form-invalid-feedback>
                   The description cannot be empty. Please provide a detailed description for your layer.
                   </b-form-invalid-feedback>
@@ -37,80 +58,74 @@
                   <b-form-input v-model="license" type="text" required placeholder="MIT"></b-form-input>
                 </b-form-group>
                 <span id="disabled-wrapper" class="w-100" tabindex="0">
-                  <b-button class="w-100" v-on:click="submit_layer" v-bind:disabled="!is_form_valid" variant="primary"><font-awesome-icon icon="paper-plane" /> Submit Lambda Layer for Review</b-button>
+                  <b-button class="w-100" v-on:click="submitLayer" v-bind:disabled="!isFormValid" variant="primary" size="lg">
+                    <font-awesome-icon icon="paper-plane" /> Submit Lambda Layer for Review
+                  </b-button>
                 </span>
-                <b-tooltip placement="bottom" target="disabled-wrapper" v-if="!is_form_valid">
+                <b-tooltip placement="bottom" target="disabled-wrapper" v-if="!isFormValid">
                   Please complete the form before submitting. Make sure there are no errors.
                 </b-tooltip>
-            </b-form>
+              </b-form>
+            </div>
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </template>
 <script>
-import apiService from '../lib/api.js';
+import * as apiService from '../lib/api.js';
 
-/* eslint-disable no-alert, no-console */
-const get_default_data = function () {
+function getDefaultData() {
   return {
-    layer_arn: '',
-    source_link: '',
-    submitter_name: '',
+    layerArn: '',
+    sourceLink: '',
+    submitterName: '',
     description: '',
     license: '',
-    valid_layer: null,
-    valid_description: false
+    validLayer: null,
+    validDescription: false
   }
 }
 
 export default {
-    name: 'SubmitLambdaLayer',
-    props: {},
-    data: get_default_data,
-    computed: {
-      is_form_valid: function() {
-        return (
-          this.valid_layer,
-          this.is_description_valid
-        )
-      },
-      is_description_valid: function() {
-        return this.description.trim() !== '';
-      }
+  name: 'SubmitLambdaLayer',
+  props: {},
+  data: getDefaultData,
+  computed: {
+    isFormValid() {
+      return this.validLayer && this.isDescriptionValid;
     },
-    methods: {
-      validate_layer: async function() {
-        this.valid_layer = await apiService.isValidAndExistingLayer(
-          this.layer_arn
-        );
-      },
-      submit_layer: async function() {
-        const submission_data = {
-          'layer_arn': this.layer_arn,
-          'source_link': this.source_link,
-          'submitter_name': this.submitter_name,
-          'description': this.description,
-          'license': this.license
-        };
-
-        await apiService.submitLayerSubmission(
-          submission_data
-        );
-
-        this.$router.push('/submission-successful');
-      }
+    isDescriptionValid() {
+      return this.description.trim() !== '';
     }
+  },
+  methods: {
+    async validateLayer() {
+      this.validLayer = await apiService.isValidAndExistingLayer(
+        this.layerArn
+      );
+    },
+    async submitLayer() {
+      const submissionData = {
+        layerArn: this.layerArn,
+        sourceLink: this.sourceLink,
+        submitterName: this.submitterName,
+        description: this.description,
+        license: this.license
+      };
+
+      await apiService.submitLayerSubmission(
+        submissionData
+      );
+
+      await this.$router.push('/submission-successful');
+    }
+  }
 }
 </script>
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.main {
-    max-width: 600px;
-    margin: 0 auto;
-    padding-left: 10px;
-    padding-right: 10px;
-    text-align: left;
-}
-
 .disabled-wrapper{
   width: 100%;
 }

--- a/front-end/src/components/SubmitLambdaLayer.vue
+++ b/front-end/src/components/SubmitLambdaLayer.vue
@@ -1,17 +1,15 @@
 <template>
   <div class="row justify-content-center">
-    <div class="col-lg-9">
+    <div class="col-lg-8">
       <h1>Submit New Lambda Layer</h1>
       <hr/>
-      <div class="col-md-10 ml-auto mr-auto">
+      <div class="ml-2 mr-2">
         <p class="text-justify">
           This form allows you to request a new layer to be added to the list of entries. Upon submission, your layer will be submitted for review by our team. Once approved, it will be available for general use.
         </p>
       </div>
       <hr/>
-      <div class="container">
-        <div class="row justify-content-center">
-          <div class="col-lg-10">
+          <div class="col-lg-10 ml-auto mr-auto">
             <div class="submit-lambda-layer text-justify">
               <b-alert show variant="info">
                 <font-awesome-icon icon="info-circle" /> <b>Important!</b>
@@ -69,8 +67,6 @@
             </div>
           </div>
         </div>
-      </div>
-    </div>
   </div>
 </template>
 <script>

--- a/front-end/src/components/SuccessfulSubmission.vue
+++ b/front-end/src/components/SuccessfulSubmission.vue
@@ -1,31 +1,29 @@
 <template>
-    <div class="main">
-      <b-alert variant="success" show>
-        <h1><font-awesome-icon icon="check-circle" /> Submission received successfully.</h1>
-        <p>
-          Thanks for your submission, we will review it shortly.
-        </p>
-      </b-alert>
-      <hr />
-      <b-button class="w-100" to="/" variant="primary"><font-awesome-icon icon="home" /> Back to Homepage</b-button>
+
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <div class="successful-submission text-justify">
+        <b-alert variant="success" show>
+          <h1><font-awesome-icon icon="check-circle" /> Submission received successfully.</h1>
+          <p>
+            Thanks for your submission, we will review it shortly.
+          </p>
+        </b-alert>
+        <hr />
+        <b-button class="w-100" to="/" variant="primary"><font-awesome-icon icon="home" /> Back to Homepage</b-button>
+      </div>
     </div>
+  </div>
 </template>
 
 <script>
 
 /* eslint-disable no-alert, no-console */
 export default {
-    name: 'SuccessfulSubmission',
-    props: {}
+  name: 'SuccessfulSubmission',
+  props: {}
 }
 </script>
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.main {
-    max-width: 600px;
-    margin: 0 auto;
-    padding-left: 10px;
-    padding-right: 10px;
-    text-align: center;
-}
 </style>

--- a/front-end/src/components/ViewLambdaLayer.vue
+++ b/front-end/src/components/ViewLambdaLayer.vue
@@ -1,122 +1,142 @@
 <template>
-    <div class="main">
-      <h1>Lambda Layer Details</h1>
-      <b>Description: </b> <p style="white-space: pre-wrap; display: inline">{{layer.description}}</p>
-      <br />
-      <span v-if="layer.source_link.trim() !== '' && !layer.source_link.toLowerCase().startsWith('javascript')">
-        <b>Source: </b> <a v-bind:href="layer.source_link" target="_blank">{{layer.source_link}}</a>
-      </span>
-      <br />
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <div class="view-lambda-layer">
+        <h1>Lambda Layer Details</h1>
+        <hr/>
+        <div class="text-center text-muted" v-if="loading">
+          <h1 class="pt-2">
+            Loading... <b-spinner type="grow" label="Spinning"></b-spinner>
+          </h1>
+        </div>
+        <div class="text-center" v-if="error">
+          <h1 class="pt-2 text-error">
+            Error: Unable to load layer.
+          </h1>
+        </div>
+        <div class="text-justify pt-2" v-if="!loading">
+          <b>Description: </b> <p style="white-space: pre-wrap; display: inline">{{layer.description}}</p>
+          <br />
+          <span v-if="layer.sourceLink.trim() !== '' && !layer.sourceLink.toLowerCase().startsWith('javascript')">
+            <b>Source: </b> <a v-bind:href="layer.sourceLink" target="_blank">{{layer.sourceLink}}</a>
+          </span>
+          <br />
 
-      <span v-if="layer.submitter_name.trim() !== ''">
-        <b>Submitter: </b> {{layer.submitter_name}}<br />
-      </span>
-      <span v-if="layer.submitter_name.trim() === ''">
-        <b>Submitter: </b> Anonymous<br />
-      </span>
+          <span v-if="layer.submitterName.trim() !== ''">
+            <b>Submitter: </b> {{layer.submitterName}}<br />
+          </span>
+          <span v-if="layer.submitterName.trim() === ''">
+            <b>Submitter: </b> Anonymous<br />
+          </span>
 
-      <span v-if="layer.license.trim() !== ''">
-        <b>License: </b> {{layer.license}}<br />
-      </span>
-      <b-form inline>
-        <label class="mr-2">
-          <b>AWS Region: </b>
-        </label>
-        <span class="input-group-btn">
-          <b-form-select v-model="selected_region" :options="select_formatted_supported_regions" size="sm"></b-form-select>
-        </span>
-      </b-form>
-      <br />
+          <span v-if="layer.license.trim() !== ''">
+            <b>License: </b> {{layer.license}}<br />
+          </span>
+          <b-form inline>
+            <label class="mr-2">
+              <b>AWS Region: </b>
+            </label>
+            <span class="input-group-btn">
+              <b-form-select v-model="selectedRegion" :options="selectFormattedSupportedRegions" size="sm"></b-form-select>
+            </span>
+          </b-form>
+          <hr />
 
-      <div class="input-group">
-        <b-form-input v-bind:value="layer.layer_arn" disabled></b-form-input>
-        <span class="input-group-btn">
-          <button class="btn btn-primary" type="button" v-on:click="copy_layer_arn(layer.layer_arn)">
-            <font-awesome-icon icon="copy" />
-            Copy ARN
-          </button>
-        </span>
+          <b-input-group class="mt-3">
+            <b-form-input v-bind:value="layer.layerArn" size="md" readonly></b-form-input>
+            <b-input-group-append>
+              <b-button variant="primary" size="sm" v-on:click="copyLayerArn(layer.layerArn)">
+                <font-awesome-icon icon="copy" />
+                Copy ARN
+              </b-button>
+            </b-input-group-append>
+            <small class="text-muted w-100 pt-sm-1">
+              Copy the above ARN value to access this layer in your Lambda.
+            </small>
+          </b-input-group>
+          <b-button-group class="pt-2 pb-1 w-100">
+            <b-button size="sm" variant="outline-dark" v-on:click="downloadLayerZip(layer.layerArn)">
+              <font-awesome-icon icon="download" /> Download Layer .zip
+            </b-button>
+          </b-button-group>
+
+          <hr />
+          <b-button size="sm" class="w-100" to="/" variant="primary">
+            <font-awesome-icon icon="home" /> Back to Lambda Layer Search
+          </b-button>
+        </div>
       </div>
-      <div class="pt-2 pb-0">
-        <b-button block variant="primary" v-on:click="download_layer_zip(layer.layer_arn)">
-          <font-awesome-icon icon="download" /> Download Layer .zip
-        </b-button>
-      </div>
-      <hr />
-      <b-button class="w-100" to="/" variant="primary"><font-awesome-icon icon="home" /> Back to Lambda Layer Search</b-button>
     </div>
+  </div>
 </template>
 
 <script>
-import apiService from '../lib/api.js';
-import utils from '../lib/utils.js';
+import * as apiService from '../lib/api.js';
+import * as utils from '../lib/utils.js';
 
 /* eslint-disable no-alert, no-console */
 export default {
-    name: 'ViewLambdaLayer',
-    props: {},
-    data: function() {
-      return {
-        internal_layer: {
-          'layer_arn': 'arn:aws:lambda:us-west-2:xxxxxxxxxx:layer:Please_Wait:1',
-          'source_link': 'https://www.example.com',
-          'license': 'Please wait...',
-          'submitter_name': 'Please wait...'
-        },
-        supported_regions: ['us-west-2'],
-        selected_region: 'us-west-2'
-      }
-    },
-    computed: {
-      select_formatted_supported_regions: function() {
-        return this.supported_regions.map(region => {
-          return {
-            'value': region,
-            'text': region
-          }
-        })
+  name: 'ViewLambdaLayer',
+  props: {},
+  data() {
+    return {
+      loading: true,
+      error: null,
+      internalLayer: {
+        layerArn: 'arn:aws:lambda:us-west-2:xxxxxxxxxx:layer:Please_Wait:1',
+        sourceLink: 'https://www.example.com',
+        license: 'Please wait...',
+        submitterName: 'Please wait...'
       },
-      layer: function() {
+      supportedRegions: ['us-west-2'],
+      selectedRegion: 'us-west-2'
+    }
+  },
+  computed: {
+    selectFormattedSupportedRegions() {
+      return this.supportedRegions.map(region => {
         return {
-          ...this.internal_layer,
-          ...{
-            'layer_arn': utils.replaceLayerRegion(
-              this.internal_layer.layer_arn,
-              this.selected_region
-            )
-          }
+          'value': region,
+          'text': region
         }
+      })
+    },
+    layer() {
+      return {
+        ...this.internalLayer,
+        layerArn: utils.replaceLayerRegion(
+          this.internalLayer.layerArn,
+          this.selectedRegion
+        )
       }
+    }
+  },
+  methods: {
+    copyLayerArn(layerArn) {
+      this.$copyText(layerArn);
+      this.$toastr.s("Lambda layer ARN copied to clipboard!");
     },
-    methods: {
-      copy_layer_arn: function(layer_arn) {
-        this.$copyText(layer_arn);
-        this.$toastr.s("Lambda layer ARN copied to clipboard!");
-      },
-      get_supported_regions: async function() {
-        this.supported_regions = await apiService.getSupportedRegions();
-      },
-      download_layer_zip: async function(layer_arn) {
-        await apiService.downloadLayer(
-          layer_arn
-        );
-      },
+    async downloadLayerZip(layerArn) {
+      await apiService.downloadLayer(
+        layerArn
+      );
     },
-    async beforeMount(){
-      this.get_supported_regions();
-      const layerId = this.$route.params.layer_id;
-      const layerData = await apiService.getLambdaLayerInfo(layerId);
-      this.internal_layer = layerData;
-    },
+    async getLayerContents() {
+      const layerId = this.$route.params.layerId;
+      try {
+        this.internalLayer = await apiService.getLambdaLayerInfo(layerId);
+      } catch (e) {
+        this.error = 'Unable to load layer';
+      } finally {
+        this.loading = false;
+      }
+    }
+  },
+  async mounted() {
+    this.getLayerContents();
+  }
 }
 </script>
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-.main {
-    max-width: 600px;
-    margin: 0 auto;
-    padding-left: 10px;
-    padding-right: 10px;
-    text-align: left;
-}
 </style>

--- a/front-end/src/lib/utils.js
+++ b/front-end/src/lib/utils.js
@@ -1,13 +1,35 @@
-function replaceLayerRegion(layer_arn, region) {
-  const layer_parts = layer_arn.split(':');
+export function convertLayerToLocal(layer) {
+  const {
+    id,
+    layer_arn,
+    source_link,
+    submitter_name,
+    description,
+    license,
+    createdAt,
+    updatedAt
+  } = layer;
+
+  return {
+    id,
+    layerArn: layer_arn,
+    sourceLink: source_link,
+    submitterName: submitter_name,
+    description,
+    license,
+    createdAt,
+    updatedAt
+  };
+}
+
+export function replaceLayerRegion(layerArn, region) {
+  const layer_parts = layerArn.split(':');
 
   if(layer_parts.length < 8) {
-    throw 'Invalid Lambda ARN specified!';
+    throw new Error('Invalid Lambda ARN specified!');
   }
 
   layer_parts[3] = region;
 
   return layer_parts.join(':');
 }
-
-exports.replaceLayerRegion = replaceLayerRegion;

--- a/front-end/src/main.js
+++ b/front-end/src/main.js
@@ -8,44 +8,72 @@ import {faFontAwesome} from '@fortawesome/free-brands-svg-icons'
 import {fab} from '@fortawesome/free-brands-svg-icons';
 import VueClipboard from 'vue-clipboard2'
 
-import VueToastr from "vue-toastr";
+import VueToastr from 'vue-toastr';
 
 import {faEdit} from '@fortawesome/fontawesome-free-solid'
 
 library.add(fab, faEdit, faFontAwesome);
 
-Vue.component('font-awesome-icon', FontAwesomeIcon)
+Vue.component('font-awesome-icon', FontAwesomeIcon);
 
-Vue.config.productionTip = false
+Vue.config.productionTip = false;
 
-Vue.use(BootstrapVue)
-Vue.use(VueClipboard)
-Vue.use(IconsPlugin)
-Vue.use(VueRouter)
-Vue.use(VueToastr)
+Vue.use(BootstrapVue);
+Vue.use(VueClipboard);
+Vue.use(IconsPlugin);
+Vue.use(VueRouter);
+Vue.use(VueToastr);
 
 // app.js
 import './styles/bootstrap.scss';
 
 import Main from './components/Main.vue';
+import Layout from './components/Layout.vue';
 import SubmitLambdaLayer from './components/SubmitLambdaLayer.vue';
 import SuccessfulSubmission from './components/SuccessfulSubmission.vue';
 import LambdaLayerDownloader from './components/LambdaLayerDownloader.vue';
 import ViewLambdaLayer from './components/ViewLambdaLayer.vue';
 
 const routes = [
-    {path: '/', component: Main},
-    {path: '/submit', component: SubmitLambdaLayer},
-    {path: '/submission-successful', component: SuccessfulSubmission},
-    {path: '/layer-downloader', component: LambdaLayerDownloader},
-    {path: '/layer/:layer_id', component: ViewLambdaLayer}
-]
+    {
+        path: '/',
+        component: Layout,
+        children: [
+            {
+                path: '',
+                component: Main
+            },
+            {
+                path: '/submit',
+                component: SubmitLambdaLayer
+            },
+            {
+                path: '/submission-successful',
+                component: SuccessfulSubmission
+            },
+            {
+                path: '/submit',
+                component: SubmitLambdaLayer
+            },
+            {
+                path: '/layer-downloader',
+                component: LambdaLayerDownloader
+            },
+            {
+                path: '/layer/:layerId',
+                component: ViewLambdaLayer
+            }
+        ]
+    }
+];
 
 const router = new VueRouter({
-    routes // short for `routes: routes`
-})
+    routes, // short for `routes: routes`
+    base: '/',
+    // mode: 'history'
+});
 
 new Vue({
     router,
     render: h => h(App),
-}).$mount('#app')
+}).$mount('#app');

--- a/front-end/vue.config.js
+++ b/front-end/vue.config.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack')
 	
 module.exports = {
-  publicPath: './',
+  publicPath: '/',
   configureWebpack: {
     plugins: [
       new webpack.DefinePlugin({


### PR DESCRIPTION
Specifically:
- Standardized the front-end on using camelCase (refactored snake_case)
- Cleaned up a bunch of styles in the app
- Added more loading states
- Added additional text content to help the user in various places to better explain the app
- Removed anonymous functions on the front-end and replaced with named functions to provide for better stack traces
- Some additional linting rules for sanity (you can use console statements in dev mode now, thank god)

Note: There are a bunch of whitespace changes here because I de-indented the files I was working on. Otherwise my IDE kept putting spaces in the wrong place and I wanted to die. I will run a full linter run in another commit, so as to leave this code actually reviewable!